### PR TITLE
fix: consider only dimensions with size >1 for plane-coordinate

### DIFF
--- a/pylibCZIrw/czi.py
+++ b/pylibCZIrw/czi.py
@@ -642,6 +642,8 @@ class CziReader:
 
     def _create_default_plane_coords(self) -> Dict[str, int]:
         """Generates a default plane coordinates dictionary with all indexes to 0.
+        This default plane coordinate contains all dimensions reported being used by 
+        the CZI-document, but includes only dimensions for which the size is >1.
 
         Returns
         -------
@@ -651,7 +653,7 @@ class CziReader:
         return {
             dim: 0
             for dim, dim_index in self.CZI_DIMS.items()
-            if self._czi_reader.GetDimensionSize(_pylibCZIrw.DimensionIndex(dim_index)) > 0
+            if self._czi_reader.GetDimensionSize(_pylibCZIrw.DimensionIndex(dim_index)) > 1
         }
 
     def _create_plane_coords(


### PR DESCRIPTION
fix: consider only dimensions with size >1 for plane-coordinate

[x] I followed the [How to structure your PR](https://github.com/ZEISS/pylibczirw/blob/main/CONTRIBUTING.md#creating-a-pr).  
[ ] Based on [Commit Parsing](https://python-semantic-release.readthedocs.io/en/latest/commit-parsing.html): In case a new **major** release will be created (because the body or footer begins with 'BREAKING CHANGE:'), I created a new [Jupyter notebook with a matching version](https://github.com/ZEISS/pylibczirw/tree/main/doc/jupyter_notebooks).  
[ ] Based on [Commit Parsing](https://python-semantic-release.readthedocs.io/en/latest/commit-parsing.html): In case a new **minor/patch** release will be created (because PR title begins with 'feat'/('fix' or 'perf')), I optionally created a new [Jupyter notebook with a matching version](https://github.com/ZEISS/pylibczirw/tree/main/doc/jupyter_notebooks).  
[ ] In case of API changes, I updated [API.md](https://github.com/ZEISS/pylibczirw/blob/main/API.md).  

_Summary of the change(s) and which issue(s) is/are fixed_  

This is a proposal to address the issue discussed in #10 . To be clear - it is more an side-effect that this change seems to fix the problem discussed there. However - I cannot see any adverse effects from this proposal, so the line of reasoning is: why not change this and as an added benefit, it will make this case work as well.
The root cause (for the problem with #10) I see as "being a malformed CZI".

_Relevant motivation and context_  



_Dependencies required for this change_  

Fixes #10  
