### PR TITLE
chore: remove temporary debugging logic to push to PyPI

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -267,11 +267,8 @@ jobs:
       needs.CodeQualityAnalysis-Test.result == 'success' &&
       needs.CodeQualityAnalysis-Test.outputs.pypi_released == 'true'
     environment:
-      # TODO: Only for testing purposes
-      # name: pypi
-      # url: https://pypi.org/project/pylibCZIrw/${{needs.CodeQualityAnalysis-Test.outputs.pypi_version}}
-      name: testpypi
-      url: https://test.pypi.org/p/pylibCZIrw/${{needs.CodeQualityAnalysis-Test.outputs.pypi_version}}
+      name: pypi
+      url: https://pypi.org/project/pylibCZIrw/${{needs.CodeQualityAnalysis-Test.outputs.pypi_version}}
     steps:
       - name: Download Wheels and Source Distribution
         uses: actions/download-artifact@v4.1.0
@@ -288,8 +285,6 @@ jobs:
         # More info on trusted publishing: https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          # TODO: Only for testing purposes (remove repository-url to push to PyPI)
-          repository-url: https://test.pypi.org/legacy/
           # Basically runs twine check
           verify-metadata: true
   Tag:


### PR DESCRIPTION
[x] I followed the [How to structure your PR](https://github.com/ZEISS/pylibczirw/blob/main/CONTRIBUTING.md#creating-a-pr).  
[ ] Based on [Commit Parsing](https://python-semantic-release.readthedocs.io/en/latest/commit-parsing.html): In case a new **major** release will be created (because the body or footer begins with 'BREAKING CHANGE:'), I created a new [Jupyter notebook with a matching version](https://github.com/ZEISS/pylibczirw/tree/main/doc/jupyter_notebooks).  
[ ] Based on [Commit Parsing](https://python-semantic-release.readthedocs.io/en/latest/commit-parsing.html): In case a new **minor/patch** release will be created (because PR title begins with 'feat'/('fix' or 'perf')), I optionally created a new [Jupyter notebook with a matching version](https://github.com/ZEISS/pylibczirw/tree/main/doc/jupyter_notebooks).  
[ ] In case of API changes, I updated [API.md](https://github.com/ZEISS/pylibczirw/blob/main/API.md).  

Remove debugging code for temporaily pushing to testpypi until infrastructure properly set up.