### PR TITLE
fix: consider only dimensions with size >1 for plane-coordinate

### DIFF
--- a/pylibCZIrw/czi.py
+++ b/pylibCZIrw/czi.py
@@ -644,6 +644,8 @@ class CziReader:
 
     def _create_default_plane_coords(self) -> Dict[str, int]:
         """Generates a default plane coordinates dictionary with all indexes to 0.
+        This default plane coordinate contains all dimensions reported being used by 
+        the CZI-document, but includes only dimensions for which the size is >1.
 
         Returns
         -------
@@ -653,7 +655,7 @@ class CziReader:
         return {
             dim: 0
             for dim, dim_index in self.CZI_DIMS.items()
-            if self._czi_reader.GetDimensionSize(_pylibCZIrw.DimensionIndex(dim_index)) > 0
+            if self._czi_reader.GetDimensionSize(_pylibCZIrw.DimensionIndex(dim_index)) > 1
         }
 
     def _create_plane_coords(

--- a/pylibCZIrw/czi.py
+++ b/pylibCZIrw/czi.py
@@ -644,7 +644,7 @@ class CziReader:
 
     def _create_default_plane_coords(self) -> Dict[str, int]:
         """Generates a default plane coordinates dictionary with all indexes to 0.
-        This default plane coordinate contains all dimensions reported being used by 
+        This default plane coordinate contains all dimensions reported being used by
         the CZI-document, but includes only dimensions for which the size is >1.
 
         Returns

--- a/pylibCZIrw/tests/unit/test_czi_reader.py
+++ b/pylibCZIrw/tests/unit/test_czi_reader.py
@@ -444,14 +444,14 @@ def test_create_roi_raises_error_on_incorrect_scene() -> None:
 @pytest.mark.parametrize(
     "GetDimensionSize, expected",
     [
-        (dimension_sizes_test1, {"C": 0}),
+        (dimension_sizes_test1, {}),
         (
             dimension_sizes_test2,
-            {"C": 0, "I": 0, "R": 0, "V": 0},
+            {"C": 0, "R": 0, "V": 0},
         ),
         (
             dimension_sizes_test3,
-            {"Z": 0, "C": 0, "T": 0, "R": 0, "I": 0, "H": 0, "V": 0, "B": 0},
+            {"Z": 0, "C": 0, "T": 0, "R": 0, "I": 0, "V": 0, "B": 0},
         ),
     ],
 )
@@ -469,17 +469,17 @@ def test_create_default_plane_coords(
 @pytest.mark.parametrize(
     "plane, GetDimensionSize, expected",
     [
-        (None, dimension_sizes_test1, {"C": 0}),
-        ({"C": 1, "Z": 3, "T": 4}, dimension_sizes_test1, {"C": 1}),
+        (None, dimension_sizes_test1, {}),
+        ({"C": 1, "Z": 3, "T": 4}, dimension_sizes_test1, {}),
         (
             {"C": 5, "Z": 3, "T": 4, "B": 12},
             dimension_sizes_test2,
-            {"C": 5, "I": 0, "R": 0, "V": 0},
+            {"C": 5, "R": 0, "V": 0},
         ),
         (
             None,
             dimension_sizes_test3,
-            {"Z": 0, "C": 0, "T": 0, "R": 0, "I": 0, "H": 0, "V": 0, "B": 0},
+            {"Z": 0, "C": 0, "T": 0, "R": 0, "I": 0, "V": 0, "B": 0},
         ),
     ],
 )


### PR DESCRIPTION
[x] I followed the [How to structure your PR](https://github.com/ZEISS/pylibczirw/blob/main/CONTRIBUTING.md#creating-a-pr).
[ ] Based on [Commit Parsing](https://python-semantic-release.readthedocs.io/en/latest/commit-parsing.html): In case a new major release will be created (because the body or footer begins with 'BREAKING CHANGE:'), I created a new [Jupyter notebook with a matching version](https://github.com/ZEISS/pylibczirw/tree/main/doc/jupyter_notebooks).
[ ] Based on [Commit Parsing](https://python-semantic-release.readthedocs.io/en/latest/commit-parsing.html): In case a new minor/patch release will be created (because PR title begins with 'feat'/('fix' or 'perf')), I optionally created a new [Jupyter notebook with a matching version](https://github.com/ZEISS/pylibczirw/tree/main/doc/jupyter_notebooks).
[ ] In case of API changes, I updated [API.md](https://github.com/ZEISS/pylibczirw/blob/main/API.md).

Re-write of https://github.com/ZEISS/pylibczirw/pull/16 and https://github.com/ZEISS/pylibczirw/pull/28 due to changes in infrastructure.

Fixes https://github.com/ZEISS/pylibczirw/issues/10
