### PR TITLE
feat: Support python upto 3.13

### DIFF
--- a/.github/actions/steps_psr/action.yml
+++ b/.github/actions/steps_psr/action.yml
@@ -27,6 +27,9 @@ runs:
       with:
         python-version: "${{inputs.PyVersionLatest}}"
         architecture: x64
+    - name: Install dependencies
+      run: python -m pip install packaging setuptools
+      shell: bash
     - name: PSR Setup
       # Pin to 8.* to not face regressions w/o knowing
       run: python -m pip install python-semantic-release==8.*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     uses: "./.github/workflows/build-reusable.yml"
     with:
       Pure: false
-      PyVersionLatest: "3.11"
+      PyVersionLatest: "3.13"
       # Relative to github.workspace
       PkgName: pylibCZIrw
       CIBWBEFOREALLLINUX: yum install -y glibc-static perl-IPC-Cmd

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -21,7 +21,7 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-pytest]
 ignore_missing_imports = True
-[mypy-distutils.version]
+[mypy-packaging.version]
 ignore_missing_imports = True
 [mypy-setuptools.*]
 ignore_missing_imports = True

--- a/doc/jupyter_notebooks/pylibCZIrw_4_1_0.ipynb
+++ b/doc/jupyter_notebooks/pylibCZIrw_4_1_0.ipynb
@@ -1347,7 +1347,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/setup.py
+++ b/setup.py
@@ -244,7 +244,7 @@ setup(
     cmdclass={"build_ext": CMakeBuild},
     install_requires=requirements,
     # we require at least python version 3.7
-    python_requires=">=3.7,<3.12",
+    python_requires=">=3.7,<3.14",
     license_files=["COPYING", "COPYING.LESSER", "NOTICE"],
     # Classifiers help users find your project by categorizing it.
     # For a list of valid classifiers, see https://pypi.org/classifiers/
@@ -256,6 +256,8 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
         "Operating System :: Microsoft :: Windows",
         "Operating System :: Unix",

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ import platform
 import re
 import subprocess  # nosec blacklist
 import sys
-from distutils.version import LooseVersion
 from pathlib import Path
 from typing import List
 
+from packaging.version import Version
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
@@ -23,7 +23,7 @@ with open("CHANGELOG.md", encoding="utf-8") as changelog_file:
     changelog = changelog_file.read()
 
 # List any runtime requirements here
-requirements = ["numpy", "cmake", "xmltodict", "validators"]
+requirements = ["numpy", "cmake", "xmltodict", "validators", "packaging"]
 
 
 class CMakeExtension(Extension):
@@ -46,14 +46,10 @@ class CMakeBuild(build_ext):
                 f"CMake must be installed and available at PATH ({os.environ.get('PATH')}) "
                 f"to build the following extensions: {', '.join(e.name for e in self.extensions)}"
             ) from exc
-        cmake_version = LooseVersion(
-            re.search(r"version\s*([\d.]+)", out.decode()).group(1)  # type: ignore[union-attr]
-        )
+        cmake_version = Version(re.search(r"version\s*([\d.]+)", out.decode()).group(1))  # type: ignore[union-attr]
         if platform.system() == "Windows":
-            cmake_version = LooseVersion(
-                re.search(r"version\s*([\d.]+)", out.decode()).group(1)  # type: ignore[union-attr]
-            )
-            if cmake_version < "3.1.0":
+            cmake_version = Version(re.search(r"version\s*([\d.]+)", out.decode()).group(1))  # type: ignore[union-attr]
+            if cmake_version < Version("3.1.0"):
                 raise RuntimeError("CMake >= 3.1.0 is required on Windows")
 
         for ext in self.extensions:
@@ -244,14 +240,13 @@ setup(
     cmdclass={"build_ext": CMakeBuild},
     install_requires=requirements,
     # we require at least python version 3.7
-    python_requires=">=3.7,<3.14",
+    python_requires=">=3.8,<3.14",
     license_files=["COPYING", "COPYING.LESSER", "NOTICE"],
     # Classifiers help users find your project by categorizing it.
     # For a list of valid classifiers, see https://pypi.org/classifiers/
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Topic :: Scientific/Engineering :: Image Processing",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -21,11 +21,11 @@ deps =
 install_command = pip install {packages}
 commands = pytest tests --junitxml={env:TESTRESULTSPATH}/{envname}.xml --junit-prefix={envname} --cov=. --cov-report=xml:{env:COVRESULTSPATH} --cov-branch --cov-append
 changedir = pylibCZIrw
-[testenv:{py37,py38,py39,py310,py311}-linux]
+[testenv:{py37,py38,py39,py310,py311,py312,py313}-linux]
 platform = linux
 allowlist_externals = rm
 commands_post = /bin/rm -rf {envdir}
-[testenv:{py37,py38,py39,py310,py311}-win]
+[testenv:{py37,py38,py39,py310,py311,py312,py313}-win]
 platform = win32
 allowlist_externals = cmd
 commands_post = cmd /c rmdir /s /q {envdir}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py37,py38,py39,py310,py311}-{win,linux}
+envlist = {py38,py39,py310,py311,py312,py313}-{win,linux}
 # https://pytest-cov.readthedocs.io/en/latest/tox.html
 # https://pytest-cov.readthedocs.io/en/latest/config.html
 # https://coverage.readthedocs.io/en/latest/config.html
@@ -21,11 +21,11 @@ deps =
 install_command = pip install {packages}
 commands = pytest tests --junitxml={env:TESTRESULTSPATH}/{envname}.xml --junit-prefix={envname} --cov=. --cov-report=xml:{env:COVRESULTSPATH} --cov-branch --cov-append
 changedir = pylibCZIrw
-[testenv:{py37,py38,py39,py310,py311,py312,py313}-linux]
+[testenv:{py38,py39,py310,py311,py312,py313}-linux]
 platform = linux
 allowlist_externals = rm
 commands_post = /bin/rm -rf {envdir}
-[testenv:{py37,py38,py39,py310,py311,py312,py313}-win]
+[testenv:{py38,py39,py310,py311,py312,py313}-win]
 platform = win32
 allowlist_externals = cmd
 commands_post = cmd /c rmdir /s /q {envdir}


### PR DESCRIPTION
BREAKING CHANGE: We no longer support python 3.7 as it is not supported by packaging

[x] I followed the [How to structure your PR](https://github.com/ZEISS/pylibczirw/blob/main/CONTRIBUTING.md#creating-a-pr).  
[ ] Based on [Commit Parsing](https://python-semantic-release.readthedocs.io/en/latest/commit-parsing.html): In case a new **major** release will be created (because the body or footer begins with 'BREAKING CHANGE:'), I created a new [Jupyter notebook with a matching version](https://github.com/ZEISS/pylibczirw/tree/main/doc/jupyter_notebooks).  
[x] Based on [Commit Parsing](https://python-semantic-release.readthedocs.io/en/latest/commit-parsing.html): In case a new **minor/patch** release will be created (because PR title begins with 'feat'/('fix' or 'perf')), I optionally created a new [Jupyter notebook with a matching version](https://github.com/ZEISS/pylibczirw/tree/main/doc/jupyter_notebooks).  
[ ] In case of API changes, I updated [API.md](https://github.com/ZEISS/pylibczirw/blob/main/API.md).  

_Summary of the change(s) and which issue(s) is/are fixed_  
Added support for python upto 3.13
_Relevant motivation and context_  
Seems to work ootb, and new windows images have default higher version of python than 3.11
_Dependencies required for this change_  
None
