### PR TITLE
chore: Move deploy job from reusable workflow to caller workflow

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -30,6 +30,13 @@ on:
         required: false
         default: ""
         type: string
+    outputs:
+      pypi_released:
+        value: ${{ CodeQualityAnalysis-Test.outputs.pypi_released }}
+      pypi_version:
+        value: ${{ CodeQualityAnalysis-Test.outputs.pypi_version }}
+      pypi_tag:
+        value: ${{ CodeQualityAnalysis-Test.outputs.pypi_tag }}
 permissions:
   contents: read
 jobs:
@@ -241,70 +248,3 @@ jobs:
           RunShell: ${{ matrix.config.RunShell }}
           PkgVersion: "${{ steps.psr.outputs.pypi_version }}"
     needs: PackageSDist
-  Upload:
-    permissions:
-      contents: read
-      # IMPORTANT: this permission is mandatory for trusted publishing
-      id-token: write
-    needs:
-      - CodeQualityAnalysis-Test
-      - DownloadTestSdist
-      - DownloadTestWheelsPure
-      - PackageWheelsNonPure
-      - PackageWheelsPure
-      - PackageSdist
-    # Needs to run on ubuntu
-    runs-on: ubuntu-latest
-    # If conditional based on https://github.com/actions/runner/issues/491#issuecomment-850884422
-    if: |
-      always() &&
-      github.event_name != 'pull_request' &&
-      contains(fromJSON('["skipped", "success"]'), needs.DownloadTestSdist.result) &&
-      contains(fromJSON('["skipped", "success"]'), needs.DownloadTestWheelsPure.result) &&
-      contains(fromJSON('["skipped", "success"]'), needs.PackageWheelsNonPure.result) &&
-      contains(fromJSON('["skipped", "success"]'), needs.PackageWheelsPure.result) &&
-      contains(fromJSON('["skipped", "success"]'), needs.PackageSdist.result) &&
-      needs.CodeQualityAnalysis-Test.result == 'success' &&
-      needs.CodeQualityAnalysis-Test.outputs.pypi_released == 'true'
-    environment:
-      name: pypi
-      url: https://pypi.org/project/pylibCZIrw/${{needs.CodeQualityAnalysis-Test.outputs.pypi_version}}
-    steps:
-      - name: Download Wheels and Source Distribution
-        uses: actions/download-artifact@v4.1.0
-      - name: Collect Wheels and Source Distribution
-        # Move to dist as default folder for publish action
-        run: New-Item -Path "." -Name "dist" -ItemType "directory"; Get-ChildItem -Path ".\*.whl",".\*.tar.gz" -Recurse | Move-Item -Destination ".\dist"
-        shell: pwsh
-      - name: Upload to PyPI
-        # As of 06/2024, trusted publishing does not work within reusable workflows located in a different repo
-        # Tracked in:
-        # https://github.com/pypa/gh-action-pypi-publish/issues/166
-        # https://github.com/pypi/warehouse/issues/11096
-        # https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github
-        # More info on trusted publishing: https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          # Basically runs twine check
-          verify-metadata: true
-  Tag:
-    permissions:
-      contents: write
-    needs:
-      - CodeQualityAnalysis-Test
-      - Upload
-    # Aftermath of if-conditional of Upload job
-    if: always() && needs.Upload.result == 'success'
-    runs-on: windows-2019
-    steps:
-      - uses: actions/checkout@v4.1.0
-      - name: Tag with PyPI version
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: 'refs/tags/${{needs.CodeQualityAnalysis-Test.outputs.pypi_tag}}',
-              sha: context.sha
-            })

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -32,11 +32,11 @@ on:
         type: string
     outputs:
       pypi_released:
-        value: ${{ CodeQualityAnalysis-Test.outputs.pypi_released }}
+        value: ${{ jobs.CodeQualityAnalysis-Test.outputs.pypi_released }}
       pypi_version:
-        value: ${{ CodeQualityAnalysis-Test.outputs.pypi_version }}
+        value: ${{ jobs.CodeQualityAnalysis-Test.outputs.pypi_version }}
       pypi_tag:
-        value: ${{ CodeQualityAnalysis-Test.outputs.pypi_tag }}
+        value: ${{ jobs.CodeQualityAnalysis-Test.outputs.pypi_tag }}
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,13 +5,11 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
-permissions:
-  contents: write
-  # IMPORTANT: this permission is mandatory for trusted publishing
-  id-token: write
 jobs:
-  build-test-deploy:
-    name: Build, Test, Deploy to PyPI
+  build:
+    permissions:
+      contents: read
+    name: Build and Test
     uses: "./.github/workflows/build-reusable.yml"
     with:
       Pure: false
@@ -21,3 +19,62 @@ jobs:
       CIBWBEFOREALLLINUX: yum install -y glibc-static perl-IPC-Cmd
     secrets:
       CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
+  # Note: This job needs to stay outside a reusable workflow due to https://github.com/ZEISS/pylibczirw/issues/70
+  upload:
+    name: Deploy to PyPI
+    permissions:
+      contents: read
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    needs:
+      - build
+    # Needs to run on ubuntu
+    runs-on: ubuntu-latest
+    # If conditional based on https://github.com/actions/runner/issues/491#issuecomment-850884422
+    if: |
+      always() &&
+      github.event_name != 'pull_request' &&
+      needs.build.result == 'success' &&
+      needs.build.outputs.pypi_released == 'true'
+    environment:
+      name: pypi
+      url: https://pypi.org/project/pylibCZIrw/${{needs.build.outputs.pypi_version}}
+    steps:
+      - name: Download Wheels and Source Distribution
+        uses: actions/download-artifact@v4.1.0
+      - name: Collect Wheels and Source Distribution
+        # Move to dist as default folder for publish action
+        run: New-Item -Path "." -Name "dist" -ItemType "directory"; Get-ChildItem -Path ".\*.whl",".\*.tar.gz" -Recurse | Move-Item -Destination ".\dist"
+        shell: pwsh
+      - name: Upload to PyPI
+        # As of 06/2024, trusted publishing does not work within reusable workflows located in a different repo
+        # Tracked in:
+        # https://github.com/pypa/gh-action-pypi-publish/issues/166
+        # https://github.com/pypi/warehouse/issues/11096
+        # https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github
+        # More info on trusted publishing: https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # Basically runs twine check
+          verify-metadata: true
+  tag:
+    permissions:
+      contents: write
+    needs:
+      - build
+      - upload
+    # Aftermath of if-conditional of Upload job
+    if: always() && needs.upload.result == 'success'
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v4.1.0
+      - name: Tag with PyPI version
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/${{needs.build.outputs.pypi_tag}}',
+              sha: context.sha
+            })

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+# Force permissions to be set on job-level
+permissions: {}
 jobs:
   build:
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,7 @@ jobs:
           # Basically runs twine check
           verify-metadata: true
   tag:
+    name: Tag with PyPI version
     permissions:
       contents: write
     needs:


### PR DESCRIPTION
[x] I followed the [How to structure your PR](https://github.com/ZEISS/pylibczirw/blob/main/CONTRIBUTING.md#creating-a-pr).  
[ ] Based on [Commit Parsing](https://python-semantic-release.readthedocs.io/en/latest/commit-parsing.html): In case a new **major** release will be created (because the body or footer begins with 'BREAKING CHANGE:'), I created a new [Jupyter notebook with a matching version](https://github.com/ZEISS/pylibczirw/tree/main/doc/jupyter_notebooks).  
[ ] Based on [Commit Parsing](https://python-semantic-release.readthedocs.io/en/latest/commit-parsing.html): In case a new **minor/patch** release will be created (because PR title begins with 'feat'/('fix' or 'perf')), I optionally created a new [Jupyter notebook with a matching version](https://github.com/ZEISS/pylibczirw/tree/main/doc/jupyter_notebooks).  
[ ] In case of API changes, I updated [API.md](https://github.com/ZEISS/pylibczirw/blob/main/API.md).  

Fixes #70 
