### PR TITLE
feat: More complete type hints for open_czi and create_czi

### DIFF
--- a/pylibCZIrw/czi.py
+++ b/pylibCZIrw/czi.py
@@ -1270,7 +1270,7 @@ def open_czi(
     filepath: str,
     file_input_type: ReaderFileInputTypes = ReaderFileInputTypes.Standard,
     cache_options: Optional[CacheOptions] = None,
-) -> Generator:
+) -> Generator[CziReader]:
     """Initialize a czi reader object and returns it.
     Opens the filepath and hands it over to the low-level function.
 
@@ -1296,7 +1296,7 @@ def open_czi(
 
 
 @contextlib.contextmanager
-def create_czi(filepath: str, exist_ok: bool = False, compression_options: Optional[str] = None) -> Generator:
+def create_czi(filepath: str, exist_ok: bool = False, compression_options: Optional[str] = None) -> Generator[CziWriter]:
     """Initialize a czi writer object and returns it. Opens the filepath and hands it over to the low-level function.
 
     Any missing intermediate directories are created in case they are missing.


### PR DESCRIPTION
**---ADAPT ME---**  
[x] I followed the [How to structure your PR](https://github.com/ZEISS/pylibczirw/blob/main/CONTRIBUTING.md#creating-a-pr).  
[ ] Based on [Commit Parsing](https://python-semantic-release.readthedocs.io/en/latest/commit-parsing.html): In case a new **major** release will be created (because the body or footer begins with 'BREAKING CHANGE:'), I created a new [Jupyter notebook with a matching version](https://github.com/ZEISS/pylibczirw/tree/main/doc/jupyter_notebooks).  
[ ] Based on [Commit Parsing](https://python-semantic-release.readthedocs.io/en/latest/commit-parsing.html): In case a new **minor/patch** release will be created (because PR title begins with 'feat'/('fix' or 'perf')), I optionally created a new [Jupyter notebook with a matching version](https://github.com/ZEISS/pylibczirw/tree/main/doc/jupyter_notebooks).  
[ ] In case of API changes, I updated [API.md](https://github.com/ZEISS/pylibczirw/blob/main/API.md).  

# Issue
If a user does the following, the most narrow inferred type for `file` is `Any`, but `file` is a `CziReader`.
```python
from pylibCZIrw import czi

with czi.open_czi(file_path) as file:
    file
```

# Changes
Specify yield type for `open_czi` and `create_czi`