### PR TITLE
fix: pre-populate eigen for CI

### DIFF
--- a/.github/scripts/install_manylinux_deps.sh
+++ b/.github/scripts/install_manylinux_deps.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 yum install -y glibc-static perl-IPC-Cmd curl ca-certificates
 
 if yum list available eigen3-devel >/dev/null 2>&1; then
-  yum install -y eigen3-devel
-  exit 0
+	yum install -y eigen3-devel
+	exit 0
 fi
 
 echo "eigen3-devel is unavailable; installing pinned Eigen headers."
@@ -21,19 +21,19 @@ mkdir -p "${eigen_workdir}" "${eigen_prefix}/include/eigen3" "${eigen_prefix}/sh
 
 downloaded_eigen=0
 for eigen_url in \
-  "https://github.com/eigen-mirror/eigen/archive/refs/tags/${eigen_version}.tar.gz" \
-  "https://gitlab.com/libeigen/eigen/-/archive/${eigen_commit}/eigen-${eigen_commit}.tar.gz"; do
-  rm -f "${eigen_archive}"
-  if curl --fail --location --retry 5 --retry-delay 5 --connect-timeout 30 \
-    "${eigen_url}" --output "${eigen_archive}"; then
-    downloaded_eigen=1
-    break
-  fi
+	"https://github.com/eigen-mirror/eigen/archive/refs/tags/${eigen_version}.tar.gz" \
+	"https://gitlab.com/libeigen/eigen/-/archive/${eigen_commit}/eigen-${eigen_commit}.tar.gz"; do
+	rm -f "${eigen_archive}"
+	if curl --fail --location --retry 5 --retry-delay 5 --connect-timeout 30 \
+		"${eigen_url}" --output "${eigen_archive}"; then
+		downloaded_eigen=1
+		break
+	fi
 done
 
 if [[ "${downloaded_eigen}" != "1" || ! -s "${eigen_archive}" ]]; then
-  echo "Failed to download Eigen ${eigen_version}." >&2
-  exit 1
+	echo "Failed to download Eigen ${eigen_version}." >&2
+	exit 1
 fi
 
 tar -xzf "${eigen_archive}" -C "${eigen_workdir}" --strip-components=1

--- a/.github/scripts/install_manylinux_deps.sh
+++ b/.github/scripts/install_manylinux_deps.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+yum install -y glibc-static perl-IPC-Cmd curl ca-certificates
+
+if yum list available eigen3-devel >/dev/null 2>&1; then
+  yum install -y eigen3-devel
+  exit 0
+fi
+
+echo "eigen3-devel is unavailable; installing pinned Eigen headers."
+
+eigen_version="3.4.0"
+eigen_commit="3147391d946bb4b6c68edd901f2add6ac1f31f8c"
+eigen_prefix="/opt/eigen3"
+eigen_workdir="/tmp/eigen3-install"
+eigen_archive="${eigen_workdir}/eigen.tar.gz"
+
+rm -rf "${eigen_workdir}"
+mkdir -p "${eigen_workdir}" "${eigen_prefix}/include/eigen3" "${eigen_prefix}/share/eigen3/cmake"
+
+downloaded_eigen=0
+for eigen_url in \
+  "https://github.com/eigen-mirror/eigen/archive/refs/tags/${eigen_version}.tar.gz" \
+  "https://gitlab.com/libeigen/eigen/-/archive/${eigen_commit}/eigen-${eigen_commit}.tar.gz"; do
+  rm -f "${eigen_archive}"
+  if curl --fail --location --retry 5 --retry-delay 5 --connect-timeout 30 \
+    "${eigen_url}" --output "${eigen_archive}"; then
+    downloaded_eigen=1
+    break
+  fi
+done
+
+if [[ "${downloaded_eigen}" != "1" || ! -s "${eigen_archive}" ]]; then
+  echo "Failed to download Eigen ${eigen_version}." >&2
+  exit 1
+fi
+
+tar -xzf "${eigen_archive}" -C "${eigen_workdir}" --strip-components=1
+cp -R "${eigen_workdir}/Eigen" "${eigen_prefix}/include/eigen3/"
+cp -R "${eigen_workdir}/unsupported" "${eigen_prefix}/include/eigen3/"
+
+cat >"${eigen_prefix}/share/eigen3/cmake/Eigen3Config.cmake" <<'EOF'
+get_filename_component(_eigen3_config_dir "${CMAKE_CURRENT_LIST_FILE}" PATH)
+get_filename_component(_eigen3_prefix "${_eigen3_config_dir}/../../.." ABSOLUTE)
+set(EIGEN3_INCLUDE_DIR "${_eigen3_prefix}/include/eigen3")
+
+if(NOT TARGET Eigen3::Eigen)
+  add_library(Eigen3::Eigen INTERFACE IMPORTED)
+  set_target_properties(Eigen3::Eigen PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${EIGEN3_INCLUDE_DIR}")
+endif()
+
+set(Eigen3_FOUND TRUE)
+EOF
+
+cat >"${eigen_prefix}/share/eigen3/cmake/Eigen3ConfigVersion.cmake" <<EOF
+set(PACKAGE_VERSION "${eigen_version}")
+
+if(PACKAGE_FIND_VERSION VERSION_GREATER PACKAGE_VERSION)
+  set(PACKAGE_VERSION_COMPATIBLE FALSE)
+else()
+  set(PACKAGE_VERSION_COMPATIBLE TRUE)
+  if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
+    set(PACKAGE_VERSION_EXACT TRUE)
+  endif()
+endif()
+EOF

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -142,7 +142,7 @@ jobs:
           - {
             PoolImage: windows-2022,
             OS: Windows,
-            CIBWBEFOREALL: "${{inputs.CIBWBEFOREALLWindows}}",
+            CIBWBEFOREALL: "${{inputs.CIBWBEFOREALLWINDOWS}}",
             CIBW_ENVIRONMENT: "",
           }
           - {
@@ -270,6 +270,10 @@ jobs:
         with:
           PyVersionLatest: "${{inputs.PyVersionLatest}}"
           PkgRootFolder: "${{ github.workspace }}/${{inputs.PkgRootFolder}}"
+      - name: Install Ubuntu source build dependencies
+        if: matrix.config.OS == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y libeigen3-dev
+        shell: bash
       - uses: "./.github/actions/steps_download"
         name: Download Sdist
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
       # Relative to github.workspace
       PkgName: pylibCZIrw
       CIBWBEFOREALLLINUX: bash /project/.github/scripts/install_manylinux_deps.sh
+      CIBWBEFOREALLMACOS: brew install eigen
       # Minimum MacOS version the wheels will support
       CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=10.15"
     secrets:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       PyVersionLatest: "3.13"
       # Relative to github.workspace
       PkgName: pylibCZIrw
-      CIBWBEFOREALLLINUX: yum install -y glibc-static perl-IPC-Cmd
+      CIBWBEFOREALLLINUX: yum install -y glibc-static perl-IPC-Cmd eigen3-devel
       # Minimum MacOS version the wheels will support
       CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=10.15"
     secrets:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       PyVersionLatest: "3.13"
       # Relative to github.workspace
       PkgName: pylibCZIrw
-      CIBWBEFOREALLLINUX: yum install -y glibc-static perl-IPC-Cmd eigen3-devel
+      CIBWBEFOREALLLINUX: bash /project/.github/scripts/install_manylinux_deps.sh
       # Minimum MacOS version the wheels will support
       CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=10.15"
     secrets:

--- a/setup.py
+++ b/setup.py
@@ -177,6 +177,7 @@ class CMakeBuild(build_ext):
             cmake_args += ["-DZLIB_USE_STATIC_LIBS=TRUE"]
             # Use the Eigen package installed by CIBW_BEFORE_ALL instead of cloning it once per Python wheel build.
             cmake_args += ["-DLIBCZI_BUILD_PREFER_EXTERNALPACKAGE_EIGEN3=ON"]
+            cmake_args += ["-DCMAKE_PREFIX_PATH=/opt/eigen3"]
 
         # Test install curl using vcpkg on linux
         print("env root is: " + os.environ.get("VCPKG_INSTALLATION_ROOT", ""))

--- a/setup.py
+++ b/setup.py
@@ -175,6 +175,8 @@ class CMakeBuild(build_ext):
             ]  # instruct to use the static version of libssl and libcrypto
             cmake_args += ["-DOPENSSL_ROOT_DIR=/tmp/openssl"]
             cmake_args += ["-DZLIB_USE_STATIC_LIBS=TRUE"]
+            # Use the Eigen package installed by CIBW_BEFORE_ALL instead of cloning it once per Python wheel build.
+            cmake_args += ["-DLIBCZI_BUILD_PREFER_EXTERNALPACKAGE_EIGEN3=ON"]
 
         # Test install curl using vcpkg on linux
         print("env root is: " + os.environ.get("VCPKG_INSTALLATION_ROOT", ""))

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,12 @@ class CMakeExtension(Extension):
 class CMakeBuild(build_ext):
     """Manages CMake build specifics of this module."""
 
+    @staticmethod
+    def _prefer_external_eigen3(cmake_args, prefix: str = ""):  # type: ignore[no-untyped-def]
+        cmake_args += ["-DLIBCZI_BUILD_PREFER_EXTERNALPACKAGE_EIGEN3=ON"]
+        if prefix:
+            cmake_args += [f"-DCMAKE_PREFIX_PATH={prefix}"]
+
     def run(self) -> None:
         """Runs CMake build."""
         try:
@@ -127,6 +133,7 @@ class CMakeBuild(build_ext):
                     f"-DOPENSSL_INCLUDE_DIR={os.path.join(openssl_prefix, 'include')}",
                 ]
             cmake_args += ["-DLIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL=ON"]
+            CMakeBuild._prefer_external_eigen3(cmake_args, brew_prefix)
         else:
             print("Homebrew not found, attempting to build dependencies locally")
             cmake_args += ["-DLIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL=OFF"]
@@ -176,8 +183,7 @@ class CMakeBuild(build_ext):
             cmake_args += ["-DOPENSSL_ROOT_DIR=/tmp/openssl"]
             cmake_args += ["-DZLIB_USE_STATIC_LIBS=TRUE"]
             # Use the Eigen package installed by CIBW_BEFORE_ALL instead of cloning it once per Python wheel build.
-            cmake_args += ["-DLIBCZI_BUILD_PREFER_EXTERNALPACKAGE_EIGEN3=ON"]
-            cmake_args += ["-DCMAKE_PREFIX_PATH=/opt/eigen3"]
+            CMakeBuild._prefer_external_eigen3(cmake_args, "/opt/eigen3")
 
         # Test install curl using vcpkg on linux
         print("env root is: " + os.environ.get("VCPKG_INSTALLATION_ROOT", ""))
@@ -187,7 +193,7 @@ class CMakeBuild(build_ext):
         print(f"path exists is: {test} ")
         if os.path.exists(vcpkg_installation_root):
             check_and_install_packages(
-                packages=["curl[ssl]"],
+                packages=["curl[ssl]", "eigen3"],
                 triplet="x64-linux",
                 vcpkg_root=vcpkg_installation_root,
             )
@@ -203,11 +209,19 @@ class CMakeBuild(build_ext):
             cmake_args += [
                 "-DLIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL=ON"
             ]  # if curl is available via vcpkg, then instruct to use the package-manager provided libcurl
+            CMakeBuild._prefer_external_eigen3(
+                cmake_args
+            )  # if eigen3 is available via vcpkg, then instruct to use the package-manager provided eigen3
         else:
             print("Pacakge manager missing, attempting to build libcurl dependency locally.")
             cmake_args += [
                 "-DLIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL=OFF"
             ]  # otherwise, we try to build libcurl ourselves (note: probably requires libssl-dev to be installed)
+            for eigen_prefix in ("/usr", "/usr/local"):
+                eigen_config = os.path.join(eigen_prefix, "share", "eigen3", "cmake", "Eigen3Config.cmake")
+                if os.path.exists(eigen_config):
+                    CMakeBuild._prefer_external_eigen3(cmake_args, eigen_prefix)
+                    break
 
         cmake_args += ["-DCMAKE_BUILD_TYPE=" + cfg]
         build_args = ["--", "-j2"]


### PR DESCRIPTION
**---ADAPT ME---**  
[x] I followed the [How to structure your PR](https://github.com/ZEISS/pylibczirw/blob/main/CONTRIBUTING.md#creating-a-pr).  
[ ] Based on [Commit Parsing](https://python-semantic-release.readthedocs.io/en/latest/commit-parsing.html): In case a new **major** release will be created (because the squash-commit body/footer begins with `BREAKING CHANGE:`), I created a new [Jupyter notebook with a matching version](https://github.com/ZEISS/pylibczirw/tree/main/doc/jupyter_notebooks).  
[x] Based on [Commit Parsing](https://python-semantic-release.readthedocs.io/en/latest/commit-parsing.html): In case a new **minor/patch** release will be created (because PR title begins with `feat`/`fix`/`perf`), I optionally created a new [Jupyter notebook with a matching version](https://github.com/ZEISS/pylibczirw/tree/main/doc/jupyter_notebooks).  
[ ] In case of API changes, I updated [API.md](https://github.com/ZEISS/pylibczirw/blob/main/API.md).  

_Summary of the change(s) and which issue(s) is/are fixed_
Change the way we consume eigen for CI builds
_Relevant motivation and context_
Some CI builds on main fail....
_Dependencies required for this change_  